### PR TITLE
[Feature] Add ability to watch modules 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # @artsy/express-reloadable
 
-When developing a Node app it's common to rely on tools like [`node-dev`](https://github.com/fgnass/node-dev) or [`nodemon`](https://github.com/remy/nodemon) to make the development process more rapid by automatically restarting the server instance on file-change. What `express-reloadable` does is listen for source-code changes within a subset of your app and, scanning Node's internal module cache, clears the `require` call if found. This tricks Node into thinking the module has not yet been loaded, effectively hot-swapping out your code without a full restart. Crazy-fast development speed!
+When developing a Node app it's common to rely on tools like [`node-dev`](https://github.com/fgnass/node-dev) or [`nodemon`](https://github.com/remy/nodemon) to make the development process more rapid by automatically restarting the server instance on file-change. What `express-reloadable` does is listen for source-code changes within a subset of your app and, scanning Node's internal module cache, clears the `require` call if found. This tricks Node into thinking the module has not yet been loaded, effectively hot-swapping out your code without a full restart. Additionally, when the `watchModules` option is passed, `express-reloadable` will listen for changes to NPM module code and reload on change. Useful when working with `yarn link` across packages / repos. Crazy-fast development speed!
 
-(**Disclaimer**: While this works for most of our use-cases, this is effectively a hack and hasn't been tested in all environments. Your milage may vary :)
+(**Disclaimer**: While this works for most of our use-cases, this is effectively a hack and hasn't been tested in all environments. Your mileage may vary :)
 
 **How it works**:
 - `express-reloadable` is called with a path to an app, which it then mounts
@@ -28,17 +28,29 @@ const app = express()
 
 if (isDevelopment) {
 
-  // Pass in app and current `require` context
-  const reloadAndMount = createReloadable(app, require)
+  // Pass in `app` and current `require` context
+  const mountAndReload = createReloadable(app, require)
 
-  // Note that if you need to mount an app at a particular root (`/api`), pass
-  // in `mountPoint` as an option.
-  app.use('/api', reloadAndMount(path.resolve(__dirname, 'api'), {
-    mountPoint: '/api'
+  // Pass in the path to an express sub-app and everything is taken care of
+  mountAndReload('./client')
+
+  // Full example:
+  app.use('/api', mountAndReload('./api'), {
+
+    // If you need to mount an app at a particular root (`/api`), pass in
+    // `mountPoint` as an option.
+    mountPoint: '/api',
+
+    // Or if you're using `yarn link` (or npm) to symlink external dependencies
+    // during dev, pass in an array of modules to watch. Changes made internally
+    // will be instantly available in the app.
+    watchModules: [
+      '@artsy/reaction',
+      '@artsy/artsy-xapp'
+    ]
   }))
 
-  // Otherwise, just pass in the path to the express app and everything is taken care of
-  reloadAndMount(path.resolve(__dirname, 'client'))
+  // If prod, mount apps like normal
 } else {
   app.use('/api', require('./api')
   app.use(require('./client')

--- a/example/index.js
+++ b/example/index.js
@@ -5,16 +5,16 @@ const { createReloadable, isDevelopment } = require('@artsy/express-reloadable')
 const app = express()
 
 if (isDevelopment) {
-  const reloadAndMount = createReloadable(app, require)
+  const mountAndReload = createReloadable(app, require)
 
   // Note that if you need to mount an app at a particular root (`/api`), pass
   // in `mountPoint` as an option.
-  app.use('/api', reloadAndMount(path.resolve(__dirname, 'api'), {
+  app.use('/api', mountAndReload('./api', {
     mountPoint: '/api'
   }))
 
   // Otherwise, just pass in the path to the express app and everything is taken care of
-  reloadAndMount(path.resolve(__dirname, 'client'))
+  mountAndReload('./client')
 } else {
   app.use('/api', require('./api'))
   app.use(require('./client'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/express-reloadable",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Development tool that enables hot-swapping Express server code without a restart",
   "keywords": [
     "express",


### PR DESCRIPTION
This PR adds additional watching ability, making it easy to listen for changes in `node_modules` and automatically reload dependencies on request. This is useful when working across library boundaries where `yarn link` is often used to symlink NPM deps during development. 

```javascript
mountAndReload('./desktop', {
  watchModules: [
    '@artsy/reaction-force'
  ]
})
```

Closes https://github.com/artsy/express-reloadable/issues/2