### PR TITLE
[Example] Update example with `watchModules` api option

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  node:
+    version: 8.4.0
+
+dependencies:
+  override:
+    - yarn install

--- a/example/api/index.js
+++ b/example/api/index.js
@@ -1,7 +1,8 @@
 const express = require('express')
 const app = module.exports = express()
+const { otherUsers } = require('../components/users')
 
-app.get('/users', (req, res, next) => {
+app.get('/users', (req, res) => {
   res.json([
     {
       name: 'Katherine'
@@ -11,7 +12,8 @@ app.get('/users', (req, res, next) => {
     },
     {
       name: 'Moira'
-    }
+    },
+    ...otherUsers()
   ])
 })
 

--- a/example/components/users.js
+++ b/example/components/users.js
@@ -1,0 +1,13 @@
+module.exports.otherUsers = () => {
+  return [
+    {
+      name: 'Leif'
+    },
+    {
+      name: 'The'
+    },
+    {
+      name: 'Cat'
+    }
+  ]
+}

--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const glob = require('glob')
 const path = require('path')
 const { createReloadable, isDevelopment } = require('@artsy/express-reloadable')
 
@@ -7,10 +8,16 @@ const app = express()
 if (isDevelopment) {
   const mountAndReload = createReloadable(app, require)
 
+  const modules = glob.sync('./components/**/*.js').map(name => path.resolve(name))
+
   // Note that if you need to mount an app at a particular root (`/api`), pass
   // in `mountPoint` as an option.
   app.use('/api', mountAndReload(path.resolve(__dirname, 'api'), {
-    mountPoint: '/api'
+    mountPoint: '/api',
+    watchModules: [
+      ...modules
+      // or, `some-linked-npm-module`
+    ]
   }))
 
   // Otherwise, just pass in the path to the express app and everything is taken care of
@@ -21,5 +28,5 @@ if (isDevelopment) {
 }
 
 app.listen(3000, () => {
-  console.log(`Listening on http://localhost:3000`)
+  console.log('Listening on http://localhost:3000')
 })

--- a/example/package.json
+++ b/example/package.json
@@ -8,12 +8,13 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.16.2",
-    "express": "^4.15.4"
+    "express": "^4.15.4",
+    "glob": "^7.1.2"
   },
   "scripts": {
     "start": "NODE_ENV=development node index.js"
   },
   "devDependencies": {
-    "@artsy/express-reloadable": "^1.1.2"
+    "@artsy/express-reloadable": "^1.4.0"
   }
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2,11 +2,13 @@
 # yarn lockfile v1
 
 
-"@artsy/express-reloadable@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.1.2.tgz#4cf6313d70a0e046a5bd1e65c731665c75c8b134"
+"@artsy/express-reloadable@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.3.1.tgz#206adcc56ebcf999aece7efcc34eaf1460cf90a7"
   dependencies:
+    chalk "^2.3.1"
     chokidar "^1.7.0"
+    decache "^4.4.0"
 
 abbrev@1:
   version "1.1.0"
@@ -29,6 +31,12 @@ ajv@^4.9.1:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
 
 anymatch@^1.3.0:
   version "1.3.2"
@@ -142,9 +150,21 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+chalk@^2.3.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chokidar@^1.7.0:
   version "1.7.0"
@@ -168,6 +188,16 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -221,6 +251,12 @@ debug@2.6.8, debug@^2.2.0, debug@^2.4.5:
   dependencies:
     ms "2.0.0"
 
+decache@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/decache/-/decache-4.4.0.tgz#6f6df6b85d7e7c4410a932ffc26489b78e9acd13"
+  dependencies:
+    callsite "^1.0.0"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -258,6 +294,10 @@ encodeurl@~1.0.1:
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 etag@~1.8.0:
   version "1.8.0"
@@ -444,7 +484,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.5:
+glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -469,6 +509,10 @@ har-validator@~4.2.1:
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1049,6 +1093,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
 
 tar-pack@^3.4.0:
   version "3.4.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,3 +28,10 @@ test('checks if throws except if NODE_ENV is set to production', (t) => {
   t.pass('No error thrown')
   t.end()
 })
+
+test('---', (t) => {
+  t.end()
+  process.exit(0)
+})
+
+


### PR DESCRIPTION
Shows how one can also use `glob` to watch internal modules, in addition to external `node_modules`. 