### PR TITLE
[Renovate] Ignore example folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "assignees": [
     "zephraph",
     "damassi"
-  ] 
+  ],
+  "ignorePaths": [
+    "example"
+  ]
 }


### PR DESCRIPTION
If auto merge is enabled and the project depends on itself, it will send renovate into a loop. This ignores the examples folder so as to prevent this. 