### PR TITLE
bugfix: Dont consume errors in reload cycle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@5.1.3
-  auto: artsy/auto@1.3.2
+  yarn: artsy/yarn@6.0.0
+  auto: artsy/auto@1.4.0
 
 workflows:
   build_and_verify:

--- a/index.js
+++ b/index.js
@@ -6,95 +6,98 @@ const decache = require('decache')
 
 function createReloadable (app, require) {
   return (folderPath, options = {}) => {
-    if (isDevelopment) {
-      const {
-        watchModules = [],
-        mountPoint = '/',
-        recursive = false
-      } = options
-
-      // On new request re-require app files
-      const onReload = (req, res, next) => {
-        const module = require(folderPath)
-
-        // Check if ES6 default export
-        if (module.default) {
-          module.default(req, res, next)
-        } else {
-          module(req, res, next)
-        }
-      }
-
-      const rootPath = path.resolve(folderPath)
-
-      const watchPaths = watchModules
-        .map(module => path.dirname(require.resolve(module)))
-        .concat([rootPath])
-
-      // Watch a subset of files for changes
-      watchPaths.forEach(folder => {
-        const watcher = require('chokidar').watch(folder)
-
-        watcher.on('ready', () => {
-          watcher.on('change', file => console.log(`[@artsy/express-reloadable] File ${chalk.grey(file)} has changed.`))
-
-          watcher.on('all', () => {
-            Object.keys(require.cache).forEach(id => {
-              if (id.startsWith(rootPath) || id.startsWith(folder)) {
-                if (recursive) {
-                  decache(id)
-                } else {
-                  delete require.cache[id]
-                }
-              }
-            })
-          })
-        })
-      })
-
-      let currentResponse = null
-      let currentNext = null
-
-      app.use((req, res, next) => {
-        currentResponse = res
-        currentNext = next
-
-        res.on('finish', () => {
-          currentResponse = null
-          currentNext = null
-        })
-
-        next()
-      })
-
-      /**
-       * In case of an uncaught exception show it to the user and proceed, rather
-       * than exiting the process.
-       */
-      process.on('uncaughtException', (error) => {
-        if (currentResponse) {
-          currentNext(error)
-          currentResponse = null
-          currentNext = null
-        } else {
-          console.log(error)
-        }
-      })
-
-      app.use(mountPoint, (req, res, next) => {
-        onReload(req, res, next)
-      })
-
-      console.log(`\n\n[@artsy/express-reloadable] Mounting: \n${chalk.grey(watchPaths.join('\n'))}\n`)
-      return onReload
-
-      // Node env not 'development', exit
-    } else {
+    if (!isDevelopment) {
       throw new Error(
         '[lib/reloadable.js] NODE_ENV must be set to "development" to use ' +
         'reloadable.js'
       )
     }
+
+    const {
+      watchModules = [],
+      mountPoint = '/',
+      recursive = false
+    } = options
+
+    // On new request re-require app files
+    const onReload = (req, res, next) => {
+      const module = require(folderPath)
+
+      // Check if ES6 default export
+      if (module.default) {
+        module.default(req, res, next)
+      } else {
+        module(req, res, next)
+      }
+    }
+
+    const rootPath = path.resolve(folderPath)
+
+    const watchPaths = watchModules
+      .map(module => path.dirname(require.resolve(module)))
+      .concat([rootPath])
+
+    // Watch a subset of files for changes
+    watchPaths.forEach(folder => {
+      const watcher = require('chokidar').watch(folder)
+
+      watcher.on('ready', () => {
+        watcher.on('change', file => console.log(`[@artsy/express-reloadable] File ${chalk.grey(file)} has changed.`))
+
+        watcher.on('all', () => {
+          Object.keys(require.cache).forEach(id => {
+            if (id.startsWith(rootPath) || id.startsWith(folder)) {
+              if (recursive) {
+                decache(id)
+              } else {
+                delete require.cache[id]
+              }
+            }
+          })
+        })
+      })
+    })
+
+    let currentResponse = null
+    let currentNext = null
+
+    app.use((req, res, next) => {
+      currentResponse = res
+      currentNext = next
+
+      res.on('finish', () => {
+        currentResponse = null
+        currentNext = null
+      })
+
+      next()
+    })
+
+    /**
+     * In case of an uncaught exception show it to the user and proceed, rather
+     * than exiting the process.
+     */
+    process.on('uncaughtException', (error) => {
+      if (currentResponse) {
+        currentNext(error)
+        currentResponse = null
+        currentNext = null
+      } else {
+        console.log(error)
+      }
+    })
+
+    app.use(mountPoint, (req, res, next) => {
+      try {
+        onReload(req, res, next)
+      } catch (error) {
+        console.error(error)
+        next(error)
+      }
+    })
+
+    console.log(`\n\n[@artsy/express-reloadable] Mounting: \n${chalk.grey(watchPaths.join('\n'))}\n`)
+    return onReload
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/express-reloadable",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Development tool that enables hot-swapping Express server code without a restart",
   "keywords": [
     "express",


### PR DESCRIPTION
Fixes an issue we were seeing where booting an app in development consumed errors if the error lived lower than the reloadable req/res cycle. Surprised this hasn't come up earlier.  